### PR TITLE
Add support for the new interface of Redis' `internal_send_command`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "redis": "0.7.2",
+    "redis": "~2.6.5",
     "tape": "^4.4.0"
   },
   "optionalDependencies": {},


### PR DESCRIPTION
This PR aims to resolve #5 

# General

The way `internal_send_command` is proxied is improved, so that invocations with both a single object argument and 3 separate arguments are supported. This way the lib should be compatible with both the current Redis versions (>= `2.6.0`) as well as the previous ones.

# Potential improvements

Means to automatically test the module against different redis versions can be added. I.e. https://github.com/joliss/node-multidep can be used to install multiple redis versions, so the whole test suite can be ran against each of them.